### PR TITLE
Made this bundle compatible to all Symfony 2.2 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "target-dir": "Seiffert/CrowdAuthBundle",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "2.2.0",
+        "symfony/symfony": ">=2.2.0,<2.3",
         "seiffert/crowd-rest-bundle": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
Currently this bundle is installable for Symfony 2.0 only. In order to install it with the latest Symfony 2.2 version the requirements have to be modified. Please don't ask why I am doing a PR for a Symfony 2.2 version :)

Same as https://github.com/seiffert/crowd-rest-bundle/pull/1
